### PR TITLE
Update webhook examples

### DIFF
--- a/user_guides/webhooks/verify_webhook_samples/node/webhook.js
+++ b/user_guides/webhooks/verify_webhook_samples/node/webhook.js
@@ -15,12 +15,12 @@ const app = express();
 const port = 3000;
 const securityToken = 'tandawebhooktest';
 
-app.use(bodyParser.json());
+app.use(bodyParser.text());
 
 app.post('/', (req, res) => {
-  const payload = req.body.payload;
-  const signature = req.headers['x-hook-signature'];
-  const actualSignature = crypto.createHmac('sha1', securityToken).update(JSON.stringify(payload)).digest('hex');
+  const payload = req.body;
+  const signature = req.headers['x-webhook-signature'];
+  const actualSignature = crypto.createHmac('sha1', securityToken).update(payload).digest('hex');
 
   ap(`Signature: ${signature}`);
   ap(`Actual Signature: ${actualSignature}`);

--- a/user_guides/webhooks/verify_webhook_samples/python/webhook.py
+++ b/user_guides/webhooks/verify_webhook_samples/python/webhook.py
@@ -13,17 +13,13 @@ security_token = 'tandawebhooktest'
 
 @app.route('/', methods=['POST'])
 def webhook():
-    payload = request.json.get('payload')
+    payload = request.get_data()
 
-    # the payload includes whitespace, so we need to remove it for the signatures to match up
-    formatted_payload = json.dumps(payload, separators=(',', ':'))
-
-    signature = request.headers.get('X-Hook-Signature')
-    computed_signature = hmac.new(security_token.encode(), formatted_payload.encode(), hashlib.sha1).hexdigest()
+    signature = request.headers.get('X-Webhook-Signature')
+    computed_signature = hmac.new(security_token.encode(), payload.encode(), hashlib.sha1).hexdigest()
 
     print("Signature: ", signature)
     print("Actual Signature: ", computed_signature)
-    print("Payload: ", json.dumps(payload, indent=4))
 
     return '', 204
 

--- a/user_guides/webhooks/verify_webhook_samples/ruby/webhook.rb
+++ b/user_guides/webhooks/verify_webhook_samples/ruby/webhook.rb
@@ -10,10 +10,10 @@ post '/' do
   # return response success with no content
   status 204
 
-  signature = request.env["HTTP_X_HOOK_SIGNATURE"]
-  payload = JSON.parse(request.body.read).fetch("payload")
+  signature = request.env["HTTP_X_WEBHOOK_SIGNATURE"]
+  payload = request.body.read
   security_token = "tandawebhooktest"
-  actual_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), security_token, payload.to_json)
+  actual_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), security_token, payload)
 
   ap "Signature: #{signature}"
   ap "Actual Signature: #{actual_signature}"


### PR DESCRIPTION
We now send `X-Webhook-Signature` based on the full request body. Update the examples accordingly.